### PR TITLE
Include difficulty level in exam summary

### DIFF
--- a/project.py
+++ b/project.py
@@ -603,6 +603,7 @@ class GUI_Exam(Exam):
             b = f"Test Dated: {self.start_time.strftime('%d-%B-%Y')}\nTest Started: {self.test_start}"
             c = f"Test Ended: {self.test_end}"
             d = f"Exam Duration: {round((self.end_time - self.start_time).total_seconds()/60, 2)} minutes"
+            e = f"Difficulty Level: {self.difficulty_chosen}"
         with open(f"{self.file_name}.txt", (self.file_open_mode)) as file:
             if a!= None and b==None and c==None and d==None:
                 file.write(str(f"{a}\n\n"))
@@ -622,6 +623,8 @@ class GUI_Exam(Exam):
                 file.write(str(f"{d}\n\n"))
                 return
             elif a!= None and b!=None and c!=None and d!=None:
+                if self.test_end is not None:
+                    file.write(str(f"{e}\n"))
                 file.write(str(f"{a}\n"))
                 file.write(str(f"{b}\n"))
                 file.write(str(f"{c}\n"))


### PR DESCRIPTION
## Summary
- capture the selected difficulty in `store_data`
- log the difficulty level before writing the exam summary

## Testing
- `python -m py_compile project.py`
- `python project.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_68692ae3fefc8333bd8f669eeb4f0eec