### PR TITLE
Add interactive Prime Sieve feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Launch the exam interface with:
 python project.py
 ```
 
-Select your desired operations, choose a difficulty level (Easy, Medium or Hard) and specify the number of questions, then start the exam. After completion you can save a PDF report summarizing your results.
+Select your desired operations, choose a difficulty level (Easy, Medium or Hard) and specify the number of questions, then start the exam. After completion you can save a PDF report summarizing your results. The home screen also provides a "Prime Sieve" activity for discovering primes between 1 and 100.
 
 ## Repository contents
 - `project.py` – main program containing the GUI and quiz logic.


### PR DESCRIPTION
## Summary
- extend home screen with **Prime Sieve** activity
- implement interactive sieve of Eratosthenes grid
- highlight discovered primes and crossed out composites
- allow users to check their work
- document the new feature in README

## Testing
- `python -m py_compile project.py`

------
https://chatgpt.com/codex/tasks/task_e_6869e803d7048333bc295dfcf5fc2edc