### PR TITLE
Add interactive sieve checkbox

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Launch the exam interface with:
 python project.py
 ```
 
-Select your desired operations, choose a difficulty level (Easy, Medium or Hard) and specify the number of questions, then start the exam. After completion you can save a PDF report summarizing your results. The home screen also provides a "Prime Sieve" activity for discovering primes between 1 and 100.  A checkbox labeled **Factors & Prime Count** enables quiz questions that ask how many factors a given number has, reporting whether it is prime or composite.
+Select your desired operations, choose a difficulty level (Easy, Medium or Hard) and specify the number of questions, then start the exam. After completion you can save a PDF report summarizing your results. The home screen also provides a "Prime Sieve" activity for discovering primes between 1 and 100. You can either launch it from its button or tick the **Sieve of Eratosthenes** checkbox to jump straight into the activity. A checkbox labeled **Factors & Prime Count** enables quiz questions that ask how many factors a given number has, reporting whether it is prime or composite.
 
 ## Repository contents
 - `project.py` – main program containing the GUI and quiz logic.


### PR DESCRIPTION
## Summary
- add `Sieve of Eratosthenes` checkbox to home screen
- disable other options when selected
- launch sieve activity from Start Exam when checkbox checked
- update sieve activity with colorful buttons, reset option and voice feedback
- mention new checkbox in README

## Testing
- `python -m py_compile project.py`

------
https://chatgpt.com/codex/tasks/task_e_6869ed04feb08333aa7f8126377c2cde