### PR TITLE
Remove prime sieve from MathQuest

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Launch the exam interface with:
 python project.py
 ```
 
-Select your desired operations, choose a difficulty level (Easy, Medium or Hard) and specify the number of questions, then start the exam. After completion you can save a PDF report summarizing your results. The home screen also provides a "Prime Sieve" activity for discovering primes between 1 and 100. You can either launch it from its button or tick the **Sieve of Eratosthenes** checkbox to jump straight into the activity. A checkbox labeled **Factors & Prime Count** enables quiz questions that ask how many factors a given number has, reporting whether it is prime or composite.
+Select your desired operations, choose a difficulty level (Easy, Medium or Hard) and specify the number of questions, then start the exam. After completion you can save a PDF report summarizing your results. A checkbox labeled **Factors & Prime Count** enables quiz questions that ask how many factors a given number has, reporting whether it is prime or composite.
 
 ## Repository contents
 - `project.py` – main program containing the GUI and quiz logic.

--- a/project.py
+++ b/project.py
@@ -259,7 +259,6 @@ class GUI_Exam(Exam):
         self.divide_variable = StringVar()
         self.fraction_variable = StringVar()
         self.factors_primes_variable = StringVar()
-        self.sieve_variable = StringVar()
         self.select_all_variable = StringVar()
         self.display_question = StringVar()
         self.grade = StringVar()
@@ -280,15 +279,6 @@ class GUI_Exam(Exam):
             offvalue=None,
             font=("Bell MT", 18),
         )
-        self.sieve_checkbox = Checkbutton(
-            self.home_frame,
-            text="Sieve of Eratosthenes",
-            variable=self.sieve_variable,
-            onvalue="sieve",
-            offvalue=None,
-            font=("Bell MT", 18),
-            command=self.toggle_sieve_checkbox,
-        )
         self.select_all_checkbox = Checkbutton(self.home_frame, text="All of the above!", variable=self.select_all_variable, onvalue="select_all", offvalue=None, font=("Bell MT", 18))
         self.add_checkbox.deselect(), self.subtract_checkbox.deselect(), self.multiply_checkbox.deselect()
         self.divide_checkbox.deselect(), self.fraction_checkbox.deselect(), self.factors_primes_checkbox.deselect(), self.select_all_checkbox.deselect()
@@ -296,7 +286,6 @@ class GUI_Exam(Exam):
         self.input_num_question = Entry(self.home_frame, font=("Bell MT", 20), justify="center", width=3)
         self.start_exam_button = Button(self.home_frame, text="Start Exam!", font=("Bell MT", 14), command=self.start)
         self.factor_mode_button = Button(self.home_frame, text="Factors & Primes", font=("Bell MT", 14), command=self.launch_factor_mode)
-        self.sieve_mode_button = Button(self.home_frame, text="Prime Sieve", font=("Bell MT", 14), command=self.launch_sieve_mode)
         self.test_checkbox = Label(
             self.home_frame,
             text="Please ensure correct selections & entry!",
@@ -353,7 +342,6 @@ class GUI_Exam(Exam):
         self.fraction_checkbox.grid(row=8, column=3)
         self.factors_primes_checkbox.grid(row=8, column=4)
         self.select_all_checkbox.grid(row=8, column=5)
-        self.sieve_checkbox.grid(row=9, column=3, columnspan=2)
         self.difficulty_label.grid(row=9, column=0, columnspan=2)
         self.difficulty_menu.grid(row=9, column=2)
         Label(self.home_frame, width=38, height=5).grid(row=10, column=0, columnspan=5)
@@ -362,32 +350,6 @@ class GUI_Exam(Exam):
         Label(self.home_frame, width=38, height=5).grid(row=12, column=0, columnspan=5)
         self.start_exam_button.grid(row=13, column=0, columnspan=5)
         self.factor_mode_button.grid(row=14, column=0, columnspan=5, pady=(10,0))
-        self.sieve_mode_button.grid(row=15, column=0, columnspan=5, pady=(10,0))
-
-    def toggle_sieve_checkbox(self):
-        if self.sieve_variable.get() == "sieve":
-            for cb in [
-                self.add_checkbox,
-                self.subtract_checkbox,
-                self.multiply_checkbox,
-                self.divide_checkbox,
-                self.fraction_checkbox,
-                self.factors_primes_checkbox,
-                self.select_all_checkbox,
-            ]:
-                cb.deselect()
-                cb.config(state=DISABLED)
-        else:
-            for cb in [
-                self.add_checkbox,
-                self.subtract_checkbox,
-                self.multiply_checkbox,
-                self.divide_checkbox,
-                self.fraction_checkbox,
-                self.factors_primes_checkbox,
-                self.select_all_checkbox,
-            ]:
-                cb.config(state=NORMAL)
 
     def checkbox_status(self):
         if self.select_all_variable.get() == "select_all" and not self.input_num_question.get() == "" and str(self.input_num_question.get()).isdecimal() and int(self.input_num_question.get()) > 0:
@@ -420,9 +382,6 @@ class GUI_Exam(Exam):
     def start(self):
         """Start the exam based on user selections."""
         self.test_checkbox.grid_forget()
-        if self.sieve_variable.get() == "sieve":
-            self.launch_sieve_mode()
-            return
         if self.checkbox_status() == "Please Select atleast One option!" or self.input_num_question.get() == "" or not str(self.input_num_question.get()).isdecimal() or int(self.input_num_question.get()) <= 0:
             self.test_checkbox.grid(row=14, column=0, columnspan=5, pady=(5, 0))
         else:
@@ -480,147 +439,7 @@ class GUI_Exam(Exam):
         self.factor_frame.pack_forget()
         self.launch_home_frame()
 
-    def launch_sieve_mode(self):
-        self.home_frame.pack_forget()
-        self.sieve_frame = Frame(GUI_Exam.root)
-        self.sieve_frame.pack(fill="both", expand=1)
-        self.primes = primes_up_to(100)
-        self.total_primes = len(self.primes)
-        self.prime_count = 0
-        Label(
-            self.sieve_frame,
-            text="Sieve of Eratosthenes - Click numbers to find primes!",
-            font=("Bell MT", 30),
-        ).grid(row=0, column=0, columnspan=10, pady=10)
-        self.prime_buttons = {}
-        self.sieve_state = {}
-        for num in range(1, 101):
-            btn = Button(
-                self.sieve_frame,
-                text=str(num),
-                width=4,
-                height=2,
-                font=("Arial", 20, "bold"),
-                bg="lightblue",
-                activebackground="yellow",
-                command=lambda n=num: self.sieve_number_click(n),
-            )
-            row = (num - 1) // 10 + 1
-            col = (num - 1) % 10
-            btn.grid(row=row, column=col, padx=2, pady=2)
-            self.prime_buttons[num] = btn
-            self.sieve_state[num] = "unmarked"
 
-        self.prime_counter_label = Label(
-            self.sieve_frame,
-            text=f"Primes Found: 0/{self.total_primes}",
-            font=("Bell MT", 16),
-        )
-        self.prime_counter_label.grid(row=11, column=0, columnspan=10, pady=(10, 0))
-        self.check_sieve_button = Button(
-            self.sieve_frame,
-            text="Check My Work",
-            font=("Bell MT", 14),
-            command=self.check_sieve_work,
-        )
-        self.reset_sieve_button = Button(
-            self.sieve_frame,
-            text="Reset",
-            font=("Bell MT", 14),
-            command=self.reset_sieve,
-        )
-        self.check_sieve_button.grid(row=12, column=0, columnspan=5, pady=5)
-        self.reset_sieve_button.grid(row=12, column=5, columnspan=5, pady=5)
-        self.sieve_back_button = Button(
-            self.sieve_frame,
-            text="Back to Home",
-            font=("Bell MT", 14),
-            command=self.back_from_sieve,
-        )
-        self.sieve_back_button.grid(row=13, column=0, columnspan=10, pady=10)
-
-    def sieve_number_click(self, n):
-        if self.sieve_state.get(n) != "unmarked":
-            return
-        btn = self.prime_buttons[n]
-        btn.config(bg="yellow")
-        GUI_Exam.root.update_idletasks()
-        if n == 1:
-            messagebox.showinfo("Prime Check", "1 is not a prime number.")
-            if self.sound_variable.get() != "":
-                GUI_Exam.engine.say("1 is not a prime number")
-                GUI_Exam.engine.runAndWait()
-            self.mark_crossed(n)
-            return
-        if is_prime(n):
-            self.mark_prime(n)
-            if self.sound_variable.get() != "":
-                GUI_Exam.engine.say(f"Great! {n} is a prime!")
-                GUI_Exam.engine.say(f"Crossing out multiples of {n}!")
-                GUI_Exam.engine.runAndWait()
-            for m in range(n * 2, 101, n):
-                if self.sieve_state.get(m) == "unmarked":
-                    self.mark_crossed(m)
-        else:
-            self.mark_crossed(n)
-
-    def mark_prime(self, n):
-        btn = self.prime_buttons[n]
-        btn.config(bg="green", fg="white")
-        btn.config(state=DISABLED)
-        self.sieve_state[n] = "prime"
-        self.prime_count += 1
-        self.update_prime_counter()
-
-    def mark_crossed(self, n):
-        btn = self.prime_buttons[n]
-        btn.config(bg="lightgrey", font=("Bell MT", 16, "overstrike"))
-        btn.config(state=DISABLED)
-        self.sieve_state[n] = "crossed"
-
-    def update_prime_counter(self):
-        self.prime_counter_label.config(
-            text=f"Primes Found: {self.prime_count}/{self.total_primes}"
-        )
-
-    def check_sieve_work(self):
-        missed = [p for p in self.primes if self.sieve_state.get(p) != "prime"]
-        wrong = [
-            n
-            for n in range(2, 101)
-            if n not in self.primes and self.sieve_state.get(n) == "prime"
-        ]
-        for m in missed:
-            self.prime_buttons[m].config(bg="orange")
-        for w in wrong:
-            self.prime_buttons[w].config(bg="red")
-        if not missed and not wrong:
-            messagebox.showinfo("Check My Work", "Great job! You found all the primes!")
-        else:
-            messagebox.showinfo(
-                "Check My Work",
-                f"Missed {len(missed)} primes and {len(wrong)} incorrect selections.",
-            )
-
-    def reset_sieve(self):
-        for n in range(1, 101):
-            btn = self.prime_buttons[n]
-            btn.config(
-                bg="lightblue",
-                fg="black",
-                font=("Arial", 20, "bold"),
-                state=NORMAL,
-            )
-            self.sieve_state[n] = "unmarked"
-        self.prime_count = 0
-        self.update_prime_counter()
-
-    def back_from_sieve(self):
-        self.sieve_variable.set(None)
-        self.toggle_sieve_checkbox()
-        self.sieve_frame.pack_forget()
-        self.launch_home_frame()
-            
     def launch_exam_frame(self):
         self.status_checkbox = self.checkbox_status()                 # To fetch the user selection
         self.question_to_ask = int(self.input_num_question.get())     # To fetch how many question to ask
@@ -1263,14 +1082,6 @@ def twin_prime_pair(n: int):
         return (n, n + 2)
     return None
 
-def primes_up_to(limit: int):
-    sieve = [True] * (limit + 1)
-    sieve[0:2] = [False, False]
-    for p in range(2, int(limit ** 0.5) + 1):
-        if sieve[p]:
-            for multiple in range(p * p, limit + 1, p):
-                sieve[multiple] = False
-    return [n for n, prime in enumerate(sieve) if prime]
 
 def tell_grade(grade):
     """Provide a random congratulatory message based on the grade."""


### PR DESCRIPTION
## Summary
- remove Prime Sieve checkbox/button and related variables
- delete Sieve frame and all helper methods
- clean start logic to always launch standard exam frame
- drop unused `primes_up_to` helper
- update README to no longer mention the sieve feature

## Testing
- `python -m py_compile project.py`


------
https://chatgpt.com/codex/tasks/task_e_6869f24f872c833388004b32ad7dea54