### PR TITLE
Fix logo check in PDF header

### DIFF
--- a/project.py
+++ b/project.py
@@ -1501,8 +1501,10 @@ class GUI_Exam(Exam):
 
 class PDF(FPDF, GUI_Exam):
     def header(self):
-        # Rendering logo:
-        self.image(os.path.join(resource_dir, "logo_image.jpg"), 10, 8, 15)
+        logo_path = resource_path("logo_image.jpg")
+        if os.path.exists(logo_path):
+            # Render logo only if available
+            self.image(logo_path, 10, 8, 15)
         # Setting font: helvetica bold 15
         self.set_font("helvetica", "B", 15)
         # Calculating width of title and setting cursor position:


### PR DESCRIPTION
## Summary
- render PDF header image only when logo_image.jpg exists

## Testing
- `python -m py_compile project.py`
- `pip install fpdf`
- `pip install pyttsx3`


------
https://chatgpt.com/codex/tasks/task_e_686bd17c995083338db916b3ff8f3041