### PR TITLE
Improve HCF question generation

### DIFF
--- a/project.py
+++ b/project.py
@@ -152,7 +152,15 @@ class Exam:
                         break
                 break
             elif S == "hcf":
-                nums = random.sample(range(20, 201), random.choice([2, 3]))
+                from math import gcd
+                count = random.choice([2, 3])
+                while True:
+                    nums = random.sample(range(10, 1000), count)
+                    g = gcd(nums[0], nums[1])
+                    if count == 3:
+                        g = gcd(g, nums[2])
+                    if g > 1:
+                        break
                 method = random.choice([
                     "listing factors",
                     "prime factorization",


### PR DESCRIPTION
## Summary
- tweak HCF quiz logic
  - pick numbers between 10 and 999
  - retry until gcd > 1

## Testing
- `python project.py` *(fails: no display)*

------
https://chatgpt.com/codex/tasks/task_e_686dbffb5c9c833394d47424bf3c73dd