### PR TITLE
Add single workbook summary with index and log

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,12 +6,15 @@ MathQuest Adventures is a Python GUI application for practicing basic arithmetic
 - Python 3
 - [pyttsx3](https://pypi.org/project/pyttsx3/)
 - [fpdf](https://pypi.org/project/fpdf/)
+- [pandas](https://pypi.org/project/pandas/)
+- [openpyxl](https://pypi.org/project/openpyxl/)
+- [numpy](https://pypi.org/project/numpy/)
 - tkinter (bundled with most Python installations)
 
 Install the required packages with pip:
 
 ```bash
-pip install pyttsx3 fpdf
+pip install pyttsx3 fpdf pandas openpyxl numpy
 ```
 
 ## Running the application
@@ -22,6 +25,8 @@ python project.py
 ```
 
 Select your desired operations, choose a difficulty level (Easy, Medium or Hard) and specify the number of questions, then start the exam. Available modes include basic arithmetic, fractions, prime factorization, HCF and the new **LCM** practice. After completion you can save a PDF report summarizing your results. A checkbox labeled **Factors & Prime Count** enables quiz questions that ask how many factors a given number has, reporting whether it is prime or composite.
+
+After every quiz the app updates a single workbook named `AllSessions.xlsx` in the output folder. It contains a cumulative `Log` sheet, an `Index` sheet linking to each session's summary, and one `Summary_<number>` sheet per session.
 
 ## Repository contents
 - `project.py` – main program containing the GUI and quiz logic.


### PR DESCRIPTION
## Summary
- consolidate Excel output into one workbook `AllSessions.xlsx`
- log every question type to a `Log` sheet
- store per-session summaries as numbered sheets and record them in an `Index`
- document numpy dependency and workbook layout in the README

## Testing
- `python -m py_compile project.py`


------
https://chatgpt.com/codex/tasks/task_e_686dc2cda9a08333ba2d669c1fde7c66