### PR TITLE
Improve difficulty logging and default

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,10 @@ python project.py
 
 Select your desired operations and specify the number of questions, then start the exam. The app now adapts difficulty dynamically per operation. Past sessions are analyzed to classify questions as **Easy**, **Medium**, or **Hard**, and quizzes mix these levels automatically. Available modes include basic arithmetic, fractions, prime factorization, HCF and the new **LCM** practice. After completion you can save a PDF report summarizing your results. A checkbox labeled **Factors & Prime Count** enables quiz questions that ask how many factors a given number has, reporting whether it is prime or composite.
 
+Multiplication problems begin with a slightly softer difficulty score so early sessions use smaller numbers until performance improves.
+
 After every quiz the app updates a single workbook named `AllSessions.xlsx` in the output folder. It contains a cumulative `Log` sheet, an `Index` sheet linking to each session's summary, and one `Summary_<number>` sheet per session.
+The `Difficulty` sheet in this workbook now records one row per session with a timestamp and the difficulty score of each operation so you can see how they change over time.
 
 ## Repository contents
 - `project.py` – main program containing the GUI and quiz logic.

--- a/project.py
+++ b/project.py
@@ -66,7 +66,8 @@ DIFFICULTY_FILE = os.path.join(OUTPUT_DIR, "difficulty_scores.json")
 DEFAULT_DIFFICULTY = {
     "+": 2.0,
     "-": 2.0,
-    "*": 2.0,
+    # start multiplication slightly easier than other operations
+    "*": 1.5,
     "/": 2.0,
     "fraction": 2.0,
     "factors_primes": 2.0,
@@ -90,14 +91,19 @@ def save_difficulty_scores(scores):
 
 
 def write_difficulty_sheet(wb, scores):
-    """Overwrite Difficulty sheet with current scores in two columns."""
-    if "Difficulty" in wb.sheetnames:
-        ws = wb["Difficulty"]
-        wb.remove(ws)
-    diff_ws = wb.create_sheet("Difficulty")
-    diff_ws.append(["Operation", "Difficulty Score"])
-    for key, val in scores.items():
-        diff_ws.append([op_names.get(key, key), round(val, 2)])
+    """Append a timestamped row of difficulty scores."""
+    timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    if "Difficulty" not in wb.sheetnames:
+        diff_ws = wb.create_sheet("Difficulty")
+        headers = ["Timestamp"] + [op_names.get(k, k) for k in scores.keys()]
+        diff_ws.append(headers)
+    else:
+        diff_ws = wb["Difficulty"]
+        if diff_ws.max_row == 0:
+            headers = ["Timestamp"] + [op_names.get(k, k) for k in scores.keys()]
+            diff_ws.append(headers)
+    row = [timestamp] + [round(scores[k], 2) for k in scores.keys()]
+    diff_ws.append(row)
 
 
 difficulty_scores = load_difficulty_scores()


### PR DESCRIPTION
## Summary
- keep a historical log of operation difficulty in `AllSessions.xlsx`
- start multiplication with a lower default difficulty
- update README with info about the easier start and new log format

## Testing
- `python -m py_compile project.py`

------
https://chatgpt.com/codex/tasks/task_e_686e9051df988333a21e97f5cffc9ada