### PR TITLE
Add session difficulty logging

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Select your desired operations and specify the number of questions, then start t
 Multiplication problems begin with a slightly softer difficulty score so early sessions use smaller numbers until performance improves.
 
 After every quiz the app updates a single workbook named `AllSessions.xlsx` in the output folder. It contains a cumulative `Log` sheet, an `Index` sheet linking to each session's summary, and one `Summary_<number>` sheet per session.
-The `Difficulty` sheet in this workbook now records one row per session with a timestamp and the difficulty score of each operation so you can see how they change over time.
+The `Difficulty` sheet in this workbook records one row per session with a timestamp and the difficulty score of each operation so you can see how they change over time. These stored scores allow charts showing the evolution of difficulty and how it relates to accuracy.
 
 ## Repository contents
 - `project.py` – main program containing the GUI and quiz logic.

--- a/project.py
+++ b/project.py
@@ -106,6 +106,20 @@ def write_difficulty_sheet(wb, scores):
     diff_ws.append(row)
 
 
+def append_difficulty_session(scores):
+    """Persist difficulty scores to the AllSessions workbook."""
+    path = os.path.join(OUTPUT_DIR, "AllSessions.xlsx")
+    os.makedirs(OUTPUT_DIR, exist_ok=True)
+    if os.path.exists(path):
+        wb = load_workbook(path)
+    else:
+        wb = Workbook()
+        default = wb.active
+        wb.remove(default)
+    write_difficulty_sheet(wb, scores)
+    wb.save(path)
+
+
 difficulty_scores = load_difficulty_scores()
 
 
@@ -1937,12 +1951,11 @@ class GUI_Exam(Exam):
         link_cell.hyperlink = f"#{summary_name}!A1"
         link_cell.style = "Hyperlink"
 
-        # log difficulty scores
-        write_difficulty_sheet(wb, difficulty_scores)
+        # save workbook and then record difficulty scores for this session
+        wb.save(path)
+        append_difficulty_session(difficulty_scores)
 
         save_difficulty_scores(difficulty_scores)
-
-        wb.save(path)
 
 
 class PDF(FPDF, GUI_Exam):


### PR DESCRIPTION
## Summary
- persist difficulty scores after each session in AllSessions.xlsx
- mention new difficulty logging in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_686e9168def083338d5732ef98ba3810