### PR TITLE
Fix run loop error in pyttsx3

### DIFF
--- a/project.py
+++ b/project.py
@@ -574,9 +574,14 @@ class GUI_Exam(Exam):
         """Speak one or more text snippets safely."""
         for t in texts:
             GUI_Exam.engine.say(t)
+        # Stop any ongoing speech before starting a new run loop to
+        # avoid 'run loop already started' errors.
+        if GUI_Exam.engine.isBusy():
+            GUI_Exam.engine.stop()
         try:
             GUI_Exam.engine.runAndWait()
         except RuntimeError:
+            # In case a loop is somehow still active, stop and retry once
             GUI_Exam.engine.stop()
             GUI_Exam.engine.runAndWait()
 


### PR DESCRIPTION
## Summary
- stop the speech engine when busy before running `runAndWait`
- retry if a runtime error is thrown

## Testing
- `python -m py_compile project.py`


------
https://chatgpt.com/codex/tasks/task_e_686f102e627c8333909ba9450af0b229